### PR TITLE
Handle-ise the name of the event XML node to ensure it's value.

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -196,7 +196,7 @@
 						
 						$about = $context['event']->about();
 						
-						General::array_to_xml($xml, Array("events"=>Array($about['name'] => Array("post-values" =>$context['fields']))));
+						General::array_to_xml($xml, Array("events"=>Array(Lang::createHandle($about['name']) => Array("post-values" =>$context['fields']))));
 						
 						$template->setXML($xml->generate());
 


### PR DESCRIPTION
I'm getting an issue where events that have spaces in their names create invalid XML. Have narrowed it down to line 199 of `extension.driver.php`. Need to handle-ise the value of the event node, so changing:

```
General::array_to_xml($xml, Array("events"=>Array($about['name'] => Array("post-values" =>$context['fields']))));
```

to:

```
General::array_to_xml($xml, Array("events"=>Array(Lang::createHandle($about['name']) => Array("post-values" =>$context['fields']))));
```
