### PR TITLE
Make sure templates exists before trying to add as event Filters.

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -84,6 +84,7 @@
 
 		public function AppendEventFilter($context){
 			$templates = EmailTemplateManager::listAll();
+			if( empty($templates) ) return;
 			foreach($templates as $template){
 				$tmp[$template->getHandle()] = $template;
 			}


### PR DESCRIPTION
Safe check for templates existence, otherwise `ksort()` on line 92 will throw an error.

```
ksort() expects parameter 1 to be array, null given
```
