### PR TITLE
Change quoting style for recipients for xPath compatibility.

### DIFF
--- a/content/templates/class.tpl
+++ b/content/templates/class.tpl
@@ -8,7 +8,7 @@ Class <!-- CLASS NAME --> extends EmailTemplate{
 	public $subject = '<!-- SUBJECT -->';
 	public $reply_to_name = '<!-- REPLYTONAME -->';
 	public $reply_to_email_address = '<!-- REPLYTOEMAIL -->';
-	public $recipients = '<!-- RECIPIENTS -->';
+	public $recipients = "<!-- RECIPIENTS -->";
 	
 	public $editable = true;
 


### PR DESCRIPTION
I'm totally new to ETM and I'm trying to learn it :)

I created a new template but upon save I'm getting errors regarding quotes. I've setup the `Recepients` field with this (there's a SBL at the middle and I'm doing a cross-match)

```
/data/partners/entry[ @id=/data/last-message/entry/partner/item/@id ]/contact-details/item[ type = 'Email' ]/value
```

and it blows in new template class from `workspace/workspace/email-templates` because the single quotes from xPath filter (`'Email'`) are conflicting in PHP.

I recommend changing single quotes with double quotes as in this commit.
