### PR TITLE
Correctly set the headers for PLAIN preview just before raw output.

### DIFF
--- a/content/content.templates.php
+++ b/content/content.templates.php
@@ -249,10 +249,11 @@ Class contentExtensionemail_template_managertemplates extends ExtensionPage {
 		$this->_useTemplate = false;
 		list(,$handle, $template) = $this->_context;
 		$templates = EmailTemplateManager::load($handle);
+		$output =  $templates->preview($template);
 		if($template == 'plain'){
 			header('Content-Type:text/plain; charset=utf-8');
 		}
-		echo $templates->preview($template);
+		echo $output;
 		exit;
 	}
 	


### PR DESCRIPTION
Debug Devkit is messing with Content-type header thus PLAIN view isn't working properly when HTML view is activated as well.

In this patch, the output is gathered first, then the `Content-type` is set and the output is printed.
