### PR TITLE
Fixed debug view for plain layout.

### DIFF
--- a/content/content.templates.php
+++ b/content/content.templates.php
@@ -251,7 +251,7 @@ Class contentExtensionemail_template_managertemplates extends ExtensionPage {
 		list(,$handle, $template) = $this->_context;
 		$templates = EmailTemplateManager::load($handle);
 		$output =  $templates->preview($template);
-		if($template == 'plain'){
+		if($template == 'plain' && !isset($_REQUEST['debug'])){
 			header('Content-Type:text/plain; charset=utf-8');
 		}
 		echo $output;


### PR DESCRIPTION
#37 broke the debug view for PLAIN layouts.

We shouldn't set the content-type to `text/plain` when the debug view is requested.
