### PR TITLE
Allows for apostrophe in the email subject

### DIFF
--- a/lib/class.emailtemplate.php
+++ b/lib/class.emailtemplate.php
@@ -268,7 +268,7 @@ Class EmailTemplate extends XSLTPage{
 		}
 
 		if(empty($this->_parsedProperties['subject'])){
-			$this->_parsedProperties['subject'] = $this->evalXPath($this->subject, false);
+            $this->_parsedProperties['subject'] = $this->disableOutputEscaping($this->evalXPath($this->subject, false));
 			//$this->addParams(Array('etm-subject'=>$this->_parsedProperties['subject']));
 		}
 
@@ -286,7 +286,22 @@ Class EmailTemplate extends XSLTPage{
 	public function getParsedProperties(){
 		return $this->_parsedProperties;
 	}
-
+    
+    public function disableOutputEscaping($string)  
+    {
+        $entities = array('&apos;' => "'");
+        
+        foreach($entities as $escaped => $value)
+        {
+            if(preg_match("`$escaped`", $string))
+            {
+                $string = preg_replace("`$escaped`", $value, $string);
+            }
+        }
+        
+        return $string;
+    }
+    
 	public function getProperties(){
 		return Array(
 			'reply-to-name' => $this->reply_to_name,


### PR DESCRIPTION
The `$entities` may be expanded to include other encoded values other than `&apos;` as you wish.

```
public function disableOutputEscaping($string)  
{
    $entities = array('&apos;' => "'");

    foreach($entities as $escaped => $value)
    {
        if(preg_match("`$escaped`", $string))
        {
            $string = preg_replace("`$escaped`", $value, $string);
        }
    }

    return $string;
}
```
