### PR TITLE
Sanatize the return messages from the email server

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -193,7 +193,7 @@
 				return false;
 			}
 			catch(EmailGatewayException $e){
-				$context['errors'][] = Array('etm-' . $template->getHandle(), false, $e->getMessage());
+				$context['errors'][] = Array('etm-' . $template->getHandle(), false, General::sanitize($e->getMessage()));
 				return false;
 			}
 			return array('total'=>count($recipients), 'sent'=>$sent);


### PR DESCRIPTION
Some email servers return messages like:

```
Failed to send to <some.email@ddre.ss>: Relay denied
```

killing the XSL Processor because of the invalid tag.
