### PR TITLE
split string after not before xpath parsing

### DIFF
--- a/lib/class.emailtemplate.php
+++ b/lib/class.emailtemplate.php
@@ -81,50 +81,50 @@ class EmailTemplate extends XSLTPage
         $dom->loadXML($this->getXML());
         $xpath = new DOMXPath($dom);
         if ($multiple == true) {
-            $xpath_strings = explode(",", $xpath_string);
+
             foreach (array_keys($this->_param) as $param) {
                 $search_strings[] = '{$' . $param . '}';
             }
-            $ret = Array();
-            foreach ($xpath_strings as $xpath_string) {
-                $xpath_string = trim($xpath_string);
-                $str = str_replace($search_strings, $this->_param, $xpath_string);
-                $replacements = array();
-                preg_match_all('/\{[^\}\$]+\}/', $str, $matches);
-                $str = Array($str);
-                if (is_array($matches[0]) && !empty($matches[0])) {
-                    foreach ($matches[0] as $match) {
-                        $results = @$xpath->evaluate(trim($match, '{}'));
-                        if (is_object($results)) {
-                            if ($results->length > 0) {
-                                if (count($str) == 1) {
-                                    $str = array_fill(0, $results->length, $str[0]);
-                                }
-                                if (count($str) == $results->length) {
-                                    foreach ($results as $offset=>$result) {
-                                        $str[$offset] = str_replace($match, trim($result->textContent), $str[$offset]);
-                                    }
-                                } else {
-                                    throw new EmailTemplateException("XPath matching failed. Number of returned values in queries do not match");
-                                }
-                            } elseif ($results->length <= 0) {
-                                foreach ($str as $offset=>$val) {
-                                    $str[$offset] = '';
-                                }
-                                Symphony::Log()->pushToLog(__('Email Template Manager') . ': ' . ' Xpath query '.$match.' did not return any results, skipping. ', 100, true);
+
+            $xpath_string = trim($xpath_string);
+            $str = str_replace($search_strings, $this->_param, $xpath_string);
+            $replacements = array();
+            preg_match_all('/\{[^\}\$]+\}/', $str, $matches);
+            $str = Array($str);
+            if (is_array($matches[0]) && !empty($matches[0])) {
+                foreach ($matches[0] as $match) {
+                    $results = @$xpath->evaluate(trim($match, '{}'));
+                    if (is_object($results)) {
+                        if ($results->length > 0) {
+                            if (count($str) == 1) {
+                                $str = array_fill(0, $results->length, $str[0]);
                             }
-                        } else {
-                            if (empty($results)) {
-                                $results = '';
+                            if (count($str) == $results->length) {
+                                foreach ($results as $offset=>$result) {
+                                    $str[$offset] = str_replace($match, trim($result->textContent), $str[$offset]);
+                                }
+                            } else {
+                                throw new EmailTemplateException("XPath matching failed. Number of returned values in queries do not match");
                             }
+                        } elseif ($results->length <= 0) {
                             foreach ($str as $offset=>$val) {
-                                $str[$offset] = str_replace($match, trim($results), $str[$offset]);
+                                $str[$offset] = '';
                             }
+                            Symphony::Log()->pushToLog(__('Email Template Manager') . ': ' . ' Xpath query '.$match.' did not return any results, skipping. ', 100, true);
+                        }
+                    } else {
+                        if (empty($results)) {
+                            $results = '';
+                        }
+                        foreach ($str as $offset=>$val) {
+                            $str[$offset] = str_replace($match, trim($results), $str[$offset]);
                         }
                     }
                 }
-                $ret = array_merge($ret, $str);
             }
+
+            //split the results at the end otherwise it might split an xpath concat function
+            $ret = explode(",", implode(',', $str));
 
             return $ret;
         } else {


### PR DESCRIPTION
Probably I will have to resubmit this PR later looking at the Diff below. (not sure when I can recheck it)

However main issue I have is that I put in a concat expression go select the email address with a fallback value using substr. The problem with how it works at the moment is that the split at the top will split the xpath statement with any `,`. I think it should first parse the xpath, and then split at the end.

Below is a sample of the XPATH I am trying to use.

    {concat(/data/contact-emails/entry[@subject=/data/events/contact-form/post-values/subject]/@recipient, substring("fallback-email", 1 div not(/data/events/contact-form/post-values/subject)) )}