### PR TITLE
Fix when field has an array/complicated structure

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -124,8 +124,16 @@ class extension_email_template_manager extends Extension
 
             //Add POST as page parameters
             foreach ($context['fields'] as $field => $val) {
-                $template->addParams(Array("etm-post-".$field => $val));
-                Symphony::Engine()->Page()->_param["etm-post-".$field] = $val;
+                if (is_array($val)){
+                    foreach ($val as $key => $value) {
+                        if (is_array($value)) $value = implode($value,',');
+                        $template->addParams(Array("etm-post-".$field.'.'.$key => $value));
+                        Symphony::Engine()->Page()->_param["etm-post-".$field.'.'.$key] = $value;
+                    }
+                } else {
+                    $template->addParams(Array("etm-post-".$field => $val));
+                    Symphony::Engine()->Page()->_param["etm-post-".$field] = $val;
+                }
             }
 
             $xml = $template->processDatasources();


### PR DESCRIPTION
As I explained to @michael-e on Gitter earlier in the week when you are trying to save an entry which has a complex field, which requires saving an array this fails as it tries to pass the whole array as a string value which is incorrect. Thus it throws a 500 server error.

I'm pretty sure what I suggested needs tweaking, I only tried it with an S3 upload field which required me to pass some metadata (files uploaded via JS).

Below find an example POST which crashes the email sending:

    fields[files][mimetype][1]:application/pdf
    fields[files][filepath][1]:start-a-project/filename-1435123437.pdf
    fields[files][filename][1]:filename.pdf