### PR TITLE
Fix email template manager

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -17,7 +17,7 @@
 		<item type="image" url="http://symphonyextensions.com/creativedutchmen/email_template_manager/media/email_template_manager.jpg">Email Template Manager: Emails need pages no more</item>
 	</media>
 	<releases>
-		<release version="7.3.0" date="2016-04-20" min="2.4.x" max="2.x.x">
+		<release version="7.3.1" date="2016-08-10" min="2.4.x" max="2.x.x">
 			<![CDATA[
 - Supported on PHP 7
 - Fix compilation error with preview for Windows and Unix (see ##2375)

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -19,6 +19,13 @@
 	<releases>
 		<release version="7.3.0" date="2016-04-20" min="2.4.x" max="2.x.x">
 			<![CDATA[
+- Supported on PHP 7
+- Fix compilation error with preview for Windows and Unix (see ##2375)
+- Fix params when override parent
+			]]>
+		</release>
+		<release version="7.3.0" date="2016-04-20" min="2.4.x" max="2.x.x">
+			<![CDATA[
 - Implement attachments logic
 			]]>
 		</release>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -20,7 +20,7 @@
 		<release version="7.3.1" date="2016-08-10" min="2.4.x" max="2.x.x">
 			<![CDATA[
 - Supported on PHP 7
-- Fix compilation error with preview for Windows and Unix (see ##2375)
+- Fix compilation error with preview for Windows and Unix (see #2375)
 - Fix params when override parent
 			]]>
 		</release>

--- a/lib/class.emailtemplate.php
+++ b/lib/class.emailtemplate.php
@@ -319,7 +319,7 @@ class EmailTemplate extends XSLTPage
         );
     }
 
-    public function setXML($xml)
+    public function setXML($xml, $isFile = false)
     {
         $this->_parsedProperties = Array();
 

--- a/lib/class.emailtemplate.php
+++ b/lib/class.emailtemplate.php
@@ -184,9 +184,9 @@ class EmailTemplate extends XSLTPage
             foreach ($this->layouts as $type=>$layout) {
                 if (in_array(strtolower($type), array_map("strtolower", $layouts))) {
                     $xsl = '<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:import href="' . WORKSPACE . '/email-templates/' . $this->getHandle() . '/' . $layout.'"/>
-</xsl:stylesheet>';
+                    <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                        <xsl:import href="/' . rawurlencode(ltrim(WORKSPACE, '/')) . '/email-templates/' . $this->getHandle() . '/' . $layout.'"/>
+                    </xsl:stylesheet>';
                     $this->setXSL($xsl, false);
                     $res = $this->generate();
                     if ($res) {

--- a/lib/class.extensionpage.php
+++ b/lib/class.extensionpage.php
@@ -30,7 +30,7 @@ class ExtensionPage extends AdministrationPage
         return parent::view();
     }
 
-    public function generate()
+    public function generate($page = NULL)
     {
         if ($this->_useTemplate !== false) {
             $template = $this->viewDir . '/' . (empty($this->_useTemplate)?$this->_getTemplate($this->_type, $this->_function):$this->_useTemplate . '.xsl');


### PR DESCRIPTION
Supported on PHP 7
- Fix compilation error with 'preview plain layout' and 'preview htm layoutl'
 for Windows and Unix (see #2375) or in lib\toolkit\class.frontendpage.php , line 536
- Fix params when override parent (signature must be the same)